### PR TITLE
Default color normalization fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,6 +89,9 @@ function getColorOverrideCode(sceneDrawGroup, isFill) {
 
 //Returns a function string that sets the value to the default one and then executes the shader value code
 function getFunctionFromDefaultAndShaderValue(sceneDrawGroup, ccssProperty, defaultValue, shaderValue) {
+    if (referenceCSS[ccssProperty].type === 'color') {
+        defaultValue = color.normalize(defaultValue, tangramReference);
+    }
     var fn = `var _value='${defaultValue}';`;
     shaderValue.js.forEach(function (code) {
         fn += code;

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -196,3 +196,15 @@ it('dynamic marker-allow-overlap should generate an exception', function () {
     }`;
     assert.throws(() => tangram_carto.layerToScene(CartoCSSRenderer.render(ccss).getLayers()[0], 0));
 });
+
+it('default color must be normalized at code-generation time', function () {
+    const ccss = `
+    #layer {
+        marker-line-opacity: 1;
+        [sov_a3 = 'RUS'] {
+            marker-line-color: #FFF;
+        }
+      }`;
+    const output = tangram_carto.layerToScene(CartoCSSRenderer.render(ccss).getLayers()[0], 0);
+    assert.strictEqual(evalIfNeeded(output.draw.drawGroup0.outline.color, { sov_a3: '' }), color.normalize(getReferenceDefaultLineValue('stroke'), tangramReference));
+});


### PR DESCRIPTION
Reference default color wasn't being normalized inside callbacks, that caused a bug at Tangram's runtime, because Tangram doesn't know about color names.