### PR TITLE
order property set to handle non-overlay blending modes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ function layerToScene(layer, layerOrder) {
         processDots(scene, layer, drawGroupName);
         processLines(scene, layer, drawGroupName);
         processPolys(scene, layer, drawGroupName);
-
+        scene.draw[drawGroupName].order = layerOrder;        
         processStyle(scene, drawGroupName, layerOrder);
     }
     return scene;

--- a/test/module.js
+++ b/test/module.js
@@ -129,6 +129,7 @@ it('multiple layers', function () {
     assert.strictEqual(output.draw.drawGroup1.cap, getReferenceDefaultLineValue('stroke-linecap'));
     assert.strictEqual(output.styles.drawGroup1.blend, 'overlay');
     assert.strictEqual(output.styles.drawGroup1.blend_order, 1);
+    assert.strictEqual(output.draw.drawGroup1.order, 1);
 });
 
 it('metersperpixel', function () {


### PR DESCRIPTION
The `order` property must be set to use non overlay blending modes. See https://mapzen.com/documentation/tangram/draw/#order

This PR set the value to the layer's index.

This is probably what we want, but the exact meaning of `order` is not totally clear, Hopefully https://github.com/tangrams/tangram-docs/issues/224 clarifies it.

In the meantime, this should be merged, because at least it fixes the current behavior: additive blending generates incorrect YAMLs, and nothing is rendered.