### PR TITLE
startsWith manual polyfill added (needed because of code generation)

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -7,6 +7,11 @@ function marshall(color) {
 module.exports.marshall = marshall;
 
 function unmarshall(color, reference) {
+    if (!String.prototype.startsWith) {
+        String.prototype.startsWith = function(searchString, position){
+          return this.substr(position || 0, searchString.length) === searchString;
+      };
+    }
     function hexToInt(hex) {
         return parseInt('0x' + hex);
     }

--- a/src/color.js
+++ b/src/color.js
@@ -7,11 +7,6 @@ function marshall(color) {
 module.exports.marshall = marshall;
 
 function unmarshall(color, reference) {
-    if (!String.prototype.startsWith) {
-        String.prototype.startsWith = function(searchString, position){
-          return this.substr(position || 0, searchString.length) === searchString;
-      };
-    }
     function hexToInt(hex) {
         return parseInt('0x' + hex);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,10 @@
+//startsWith Polyfill
+if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function(searchString, position){
+      return this.substr(position || 0, searchString.length) === searchString;
+  };
+}
+
 const carto = require('carto');
 const tangramReference = require('tangram-reference').load();
 const translate = require('./translate.js');


### PR DESCRIPTION
Fix errors like this:
```
[Vector] Unable to render due \"Das Objekt unterstützt die Eigenschaft oder Methode \"startsWith\" nicht\". Full CartoCSS:\n#layer {\n  polygon-fill: #374C70;\n  polygon-opacity: 0.9;\n  ::outline {\n    line-color: #FFF;\n    line-width: 1;\n    line-opacity: 0.5;\n  }\n}
```
 (from track:js)

It happens because the `startsWith` function of the color related functions are passed as strings to tangram (code-generation), therefore, they are not poly-filled.

