### PR TITLE
Improve error messages

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -35,7 +35,7 @@ function unmarshall(color, reference) {
         result.b = rgbArray[2];
         result.a = 1;
     } else {
-        throw new Error(`color format not recognized, color: ${color}`);
+        throw new Error(`tangram-cartocss (unmarshall): color format not recognized, color: ${color}`);
     }
     return result;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ function layerToScene(layer, layerOrder) {
         textures: {}
     };
     if (layer.shader.symbolizers.length > 1) {
-        throw new Error('Multiple symbolizer on one layer is not supported');
+        throw new Error('Unsupported CartoCSS: multiple symbolizer in one layer');
     } else if (layer.shader.symbolizers.length === 1) {
         const drawGroupName = `drawGroup${layerOrder}`;
         processPoints(scene, layer, drawGroupName);
@@ -140,7 +140,7 @@ module.exports.getSupportResult = function getSupportResult(cartoCss) {
         cartoCssToDrawGroups(cartoCss);
     } catch (e) {
         result.supported = false;
-        result.reason = e.message || 'unknown';
+        result.reason = e.message || 'tangram-cartocss unknown error';
     }
     return result;
 };

--- a/src/translate.js
+++ b/src/translate.js
@@ -149,7 +149,7 @@ function defProperty(sceneDrawGroup, layer, ccssName, tangramName) {
         value = translateValue(sceneDrawGroup, ccssName, getLiteralFromShaderValue(shaderValue));
     } else {
         if (!referenceCSS[ccssName].expression) {
-            throw new Error(`Expression-controlled ${ccssName} is unsupported`);
+            throw new Error(`Unsupported CartoCSS: expression-controlled ${ccssName}`);
         }
         value = getFunctionFromDefaultAndShaderValue(sceneDrawGroup, ccssName, defaultValue, shaderValue);
     }


### PR DESCRIPTION
Improve error messages to allow upper layers to safely discard "unsupported CartoCSS" errors (without logging them anymore).
