### PR TITLE
Workaround buggy carto renderer escaping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 //Polyfills
 if (!String.prototype.startsWith) {
-    String.prototype.startsWith = function(searchString, position){
-      return this.substr(position || 0, searchString.length) === searchString;
-  };
+    String.prototype.startsWith = function (searchString, position) {
+        return this.substr(position || 0, searchString.length) === searchString;
+    };
 }
-Number.isFinite = Number.isFinite || function(value) {
+Number.isFinite = Number.isFinite || function (value) {
     return typeof value === 'number' && isFinite(value);
 };
 
@@ -105,12 +105,27 @@ function processStyle(scene, drawGroupName, layerOrder) {
     delete scene.draw[drawGroupName].blend;
 }
 
+//Work around buggy carto rendererer
+function unescapeCode(code) {
+    //carto renderer still thinks that the JS code is an XML, therefore, we need to unescape it using
+    //XML escaping rules
+    return code.replace('&amp', '&');
+}
+function unescapeShader(shader) {
+    for (var property of Object.keys(shader)) {
+        if (shader[property].js !== undefined) {
+            shader[property].js = shader[property].js.map(code => unescapeCode(code));
+        }
+    }
+}
+
 function layerToScene(layer, layerOrder) {
     var scene = {
         draw: {},
         styles: {},
         textures: {}
     };
+    unescapeShader(layer.shader);
     if (layer.shader.symbolizers.length > 1) {
         throw new Error('Unsupported CartoCSS: multiple symbolizer in one layer');
     } else if (layer.shader.symbolizers.length === 1) {

--- a/src/index.js
+++ b/src/index.js
@@ -112,11 +112,11 @@ function unescapeCode(code) {
     return code.replace('&amp', '&');
 }
 function unescapeShader(shader) {
-    for (var property of Object.keys(shader)) {
+    Object.keys(shader).forEach(function (property) {
         if (shader[property].js !== undefined) {
             shader[property].js = shader[property].js.map(code => unescapeCode(code));
         }
-    }
+    });
 }
 
 function layerToScene(layer, layerOrder) {

--- a/test/module.js
+++ b/test/module.js
@@ -239,8 +239,8 @@ describe('dot', function () {
     });
 });
 
-describe('multiple super layers', function(){
-    it('should correctly set the order property', function(){
+describe('multiple super layers', function () {
+    it('should correctly set the order property', function () {
         const ccss = `
         #layer {
             dot-fill: blue;
@@ -249,7 +249,7 @@ describe('multiple super layers', function(){
         assert.strictEqual(output.draw.drawGroup1000.order, 1000);
         assert.strictEqual(output.styles.drawGroup1000.blend_order, 1000);
     });
-    it('should correctly set the order property with multiple sub layers', function(){
+    it('should correctly set the order property with multiple sub layers', function () {
         const ccss = `
         #layer {
             line-opacity: 1;
@@ -263,5 +263,23 @@ describe('multiple super layers', function(){
         assert.strictEqual(output[0].styles.drawGroup1000.blend_order, 1000);
         assert.strictEqual(output[1].draw.drawGroup1001.order, 1001);
         assert.strictEqual(output[1].styles.drawGroup1001.blend_order, 1001);
+    });
+});
+
+describe('unescape XML ampersands', function () {
+    it('should work-around buggy carto renderer escaping', function () {
+        const ccss = `#layer {
+            marker-width: 10;
+            [ koncern = "Stockholms Restauranger & Wärdshus" ] {
+              marker-fill: #43aee4;
+            }
+            marker-fill-opacity: 1;
+            marker-allow-overlap: true;
+            marker-line-width: 1;
+            marker-line-color: #FFF;
+            marker-line-opacity: 1;
+          }`;
+        const output = tangram_carto.cartoCssToDrawGroups(ccss, 0);
+        assert.ok(!output[0].draw.drawGroup0.color.includes('&amp'));
     });
 });


### PR DESCRIPTION
Carto renderer has a bug that escapes ampersands by replacing them to `&amp`. See:
https://github.com/CartoDB/support/issues/1032
https://github.com/CartoDB/carto/issues/43

That replacement is done at https://github.com/CartoDB/carto/blob/master/lib/carto/tree/quoted.js#L12

However, there is no easy fix there, since we don't know at that file if we are targeting JS or XML.

This is just a simple work-around (and a regression test), it won't parse the JS syntax, therefore if `...&amp...` is present as code, and not as a string, it will generate an invalid JS code.

However, I think this is the more practical solution.