### PR TITLE
Fix zero opacity bug

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -44,14 +44,16 @@ function getOpacityOverride(sceneDrawGroup, isFill) {
     } else {
         opacity = sceneDrawGroup._hidden['opacity:outline'];
     }
-    opacity = sceneDrawGroup._hidden['opacity:general'] || opacity;
+    if (sceneDrawGroup._hidden['opacity:general'] !== undefined) {
+        opacity = sceneDrawGroup._hidden['opacity:general'];
+    }
     return opacity;
 }
 
 function getColorFromLiteral(sceneDrawGroup, colorLiteral, isFill) {
     const opacity = getOpacityOverride(sceneDrawGroup, isFill);
     const c = color.unmarshall(colorLiteral, tangramReference);
-    if (opacity) {
+    if (opacity !== undefined) {
         if (Number.isFinite(opacity)) {
             c.a = opacity;
             return color.marshall(c);
@@ -67,7 +69,7 @@ function getColorFromLiteral(sceneDrawGroup, colorLiteral, isFill) {
 
 function getColorOverrideCode(sceneDrawGroup, isFill) {
     const opacity = getOpacityOverride(sceneDrawGroup, isFill);
-    if (opacity) {
+    if (opacity !== undefined) {
         if (Number.isFinite(opacity)) {
             return `var c=${color.unmarshall.toString()}(_value);c.a=${opacity};_value=${color.marshall.toString()}(c);`;
         } else {

--- a/test/module.js
+++ b/test/module.js
@@ -265,3 +265,19 @@ describe('multiple super layers', function(){
         assert.strictEqual(output[1].styles.drawGroup1001.blend_order, 1001);
     });
 });
+
+describe('opacity', function(){
+    it('should handle opacity 0 correctly', function(){
+        const ccss = `#layer {
+            polygon-fill: #e3e0ea;
+            polygon-opacity: 0;
+        }
+        #layer::outline {
+            line-width: 1.5;
+            line-color: #000000;
+            line-opacity: 0.5;
+        }`;
+        const output = tangram_carto.cartoCssToDrawGroups(ccss, 0);
+        assert.strictEqual(output[0].draw.drawGroup0.color, 'rgba(227,224,234,0)');
+    });
+});


### PR DESCRIPTION
Zero opacity was being translated to one opacity because of buggy opacity checks (opacity was being checked for false-ability to check that it wasn't `undefined`, but zero-opacity was included in that check too as a result). 

A quick test:
```
const ccss = `#layer {
   	    polygon-fill: #e3e0ea;
  	    polygon-opacity: 0;
   	  }
  	  #layer::outline {
   	    line-width: 1.5;
   	    line-color: #000000;
            line-opacity: 0.5;
   	  }`;
const tangram_carto = require('../src/index.js');
const output = tangram_carto.cartoCssToDrawGroups(ccss, 0);
console.log(JSON.stringify(output));
```

A regression test could be added too.