### PR TITLE
Mapnik identifier bugfix (with regression test)

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -87,6 +87,9 @@ function getFunctionFromDefaultAndShaderValue(sceneDrawGroup, ccssProperty, defa
     }
     var fn = `var _value=${defaultValue};`;
     shaderValue.js.forEach(function (code) {
+        if (code.search(/data\['mapnik::\S+'\]/) >= 0) {
+            throw new Error('mapnik selector present in the CartoCSS');
+        }
         fn += code;
     });
     if (referenceCSS[ccssProperty].type === 'color') {

--- a/test/module.js
+++ b/test/module.js
@@ -239,8 +239,8 @@ describe('dot', function () {
     });
 });
 
-describe('multiple super layers', function(){
-    it('should correctly set the order property', function(){
+describe('multiple super layers', function () {
+    it('should correctly set the order property', function () {
         const ccss = `
         #layer {
             dot-fill: blue;
@@ -249,7 +249,7 @@ describe('multiple super layers', function(){
         assert.strictEqual(output.draw.drawGroup1000.order, 1000);
         assert.strictEqual(output.styles.drawGroup1000.blend_order, 1000);
     });
-    it('should correctly set the order property with multiple sub layers', function(){
+    it('should correctly set the order property with multiple sub layers', function () {
         const ccss = `
         #layer {
             line-opacity: 1;
@@ -266,8 +266,8 @@ describe('multiple super layers', function(){
     });
 });
 
-describe('opacity', function(){
-    it('should handle opacity 0 correctly', function(){
+describe('opacity', function () {
+    it('should handle opacity 0 correctly', function () {
         const ccss = `#layer {
             polygon-fill: #e3e0ea;
             polygon-opacity: 0;
@@ -297,5 +297,16 @@ describe('unescape of XML ampersands', function () {
           }`;
         const output = tangram_carto.cartoCssToDrawGroups(ccss, 0);
         assert.ok(!output[0].draw.drawGroup0.color.includes('&amp'));
+    });
+});
+
+describe('Unsupported CartoCSS', function () {
+    it('due to mapnik identifiers should throw an exception', function () {
+        const ccss = `#layer ['mapnik::geometry_type'=2]{
+            line-color: #4CC8A3;
+            line-width: 1.5;
+            line-opacity: 1;
+          }`;
+        assert.throws(() => { tangram_carto.cartoCssToDrawGroups(ccss, 0); });
     });
 });

--- a/test/module.js
+++ b/test/module.js
@@ -309,4 +309,12 @@ describe('Unsupported CartoCSS', function () {
           }`;
         assert.throws(() => { tangram_carto.cartoCssToDrawGroups(ccss, 0); });
     });
+    it('due to mapnik identifiers should throw an exception', function () {
+        const ccss = `#layer [ "mapnik::geometry_type" = 2]{
+            line-color: #4CC8A3;
+            line-width: 1.5;
+            line-opacity: 1;
+          }`;
+        assert.throws(() => { tangram_carto.cartoCssToDrawGroups(ccss, 0); });
+    });
 });


### PR DESCRIPTION
CartoCSS like this
```
#layer ['mapnik::geometry_type'=2]{
  line-color: #4CC8A3;
  line-width: 1.5;
  line-opacity: 1;
}
```
breaks because tangram doesn't provide mapnik's identifier at runtime, which basically deactivates the rendering of the layer.

This bugfix detects mapnik's identifiers and throws an exception to avoid detecting the problem at tangram's runtime instead of at tangram-cartocss's runtime.

Regression test added too.